### PR TITLE
Feat/payouts

### DIFF
--- a/contracts/pot/src/constants.rs
+++ b/contracts/pot/src/constants.rs
@@ -1,0 +1,2 @@
+pub const ONE_DAY_MS: u64 = 86_400_000;
+pub const ONE_WEEK_MS: u64 = ONE_DAY_MS * 7;

--- a/contracts/pot/src/internal.rs
+++ b/contracts/pot/src/internal.rs
@@ -24,4 +24,12 @@ impl Contract {
         let project_exists = self.approved_project_ids.contains(project_id);
         assert!(project_exists, "Project does not exist");
     }
+
+    pub(crate) fn assert_cooldown_period_complete(&self) {
+        assert!(
+            self.cooldown_end_ms.is_some()
+                && self.cooldown_end_ms.unwrap() < env::block_timestamp_ms(),
+            "Cooldown period is not over"
+        );
+    }
 }

--- a/contracts/pot/src/internal.rs
+++ b/contracts/pot/src/internal.rs
@@ -8,4 +8,20 @@ impl Contract {
             "Only the chef can call this method"
         );
     }
+
+    pub(crate) fn assert_round_closed(&self) {
+        assert!(
+            env::block_timestamp_ms() >= self.end_time,
+            "Round is still open"
+        );
+    }
+
+    pub(crate) fn assert_round_open(&self) {
+        assert!(env::block_timestamp_ms() < self.end_time, "Round is closed");
+    }
+
+    pub(crate) fn assert_approved_project(&self, project_id: &ProjectId) {
+        let project_exists = self.approved_project_ids.contains(project_id);
+        assert!(project_exists, "Project does not exist");
+    }
 }

--- a/contracts/pot/src/lib.rs
+++ b/contracts/pot/src/lib.rs
@@ -8,7 +8,7 @@ use near_sdk::{
 };
 
 type TimestampMs = u64;
-type ProjectId = u64; // TODO: change to AccountId?
+type ProjectId = AccountId;
 type ApplicationId = u64;
 type DonationId = u64; // TODO: change to Sring formatted as `"application_id:donation_id"`
 
@@ -66,9 +66,9 @@ pub struct Contract {
     /// Protocol fee
     pub protocol_fee_basis_points: u32, // e.g. 700 (7%)
     /// Amount of matching funds available
-    pub matching_pool_balance: U128,
+    pub total_matching_pool_funds: U128,
     /// Amount of donated funds available
-    pub donations_balance: U128,
+    pub total_donations_funds: U128,
     /// Cooldown period starts when Chef sets payouts
     pub cooldown_end_ms: Option<TimestampMs>,
     /// Have all projects been paid out?
@@ -87,6 +87,7 @@ pub struct Contract {
     pub pending_project_ids: UnorderedSet<ProjectId>,
 
     // DONATION MAPPINGS
+    // TODO: consider changing some of these to UnorderedMaps
     /// All donation records
     pub donations_by_id: LookupMap<DonationId, Donation>,
     /// IDs of donations made to a given project
@@ -209,8 +210,8 @@ impl Contract {
             max_patron_referral_fee,
             round_manager_fee_basis_points,
             protocol_fee_basis_points,
-            matching_pool_balance: U128(0),
-            donations_balance: U128(0),
+            total_matching_pool_funds: U128(0),
+            total_donations_funds: U128(0),
             cooldown_end_ms: None,
             paid_out: false,
             project_ids: UnorderedSet::new(StorageKey::ProjectIds),
@@ -283,8 +284,8 @@ impl Default for Contract {
             max_patron_referral_fee: U128(0),
             round_manager_fee_basis_points: 0,
             protocol_fee_basis_points: 0,
-            matching_pool_balance: U128(0),
-            donations_balance: U128(0),
+            total_matching_pool_funds: U128(0),
+            total_donations_funds: U128(0),
             cooldown_end_ms: None,
             paid_out: false,
             project_ids: UnorderedSet::new(StorageKey::ProjectIds),

--- a/contracts/pot/src/lib.rs
+++ b/contracts/pot/src/lib.rs
@@ -1,5 +1,5 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::collections::{LookupMap, UnorderedSet};
+use near_sdk::collections::{LookupMap, UnorderedMap, UnorderedSet};
 use near_sdk::json_types::{Base64VecU8, U128, U64};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{
@@ -89,7 +89,7 @@ pub struct Contract {
     // DONATION MAPPINGS
     // TODO: consider changing some of these to UnorderedMaps
     /// All donation records
-    pub donations_by_id: LookupMap<DonationId, Donation>,
+    pub donations_by_id: UnorderedMap<DonationId, Donation>, // can iterate over this to get all donations
     /// IDs of donations made to a given project
     pub donation_ids_by_project_id: LookupMap<ProjectId, UnorderedSet<DonationId>>,
     /// IDs of donations made by a given donor (user)
@@ -99,7 +99,7 @@ pub struct Contract {
     pub patron_donation_ids: UnorderedSet<DonationId>,
 
     // PAYOUT MAPPINGS
-    pub payouts_by_id: LookupMap<PayoutId, Payout>,
+    pub payouts_by_id: UnorderedMap<PayoutId, Payout>, // can iterate over this to get all payouts
     pub payout_ids_by_project_id: LookupMap<ProjectId, UnorderedSet<PayoutId>>,
 }
 
@@ -218,12 +218,12 @@ impl Contract {
             approved_project_ids: UnorderedSet::new(StorageKey::ApprovedProjectIds),
             rejected_project_ids: UnorderedSet::new(StorageKey::RejectedProjectIds),
             pending_project_ids: UnorderedSet::new(StorageKey::PendingProjectIds),
-            donations_by_id: LookupMap::new(StorageKey::DonationsById),
+            donations_by_id: UnorderedMap::new(StorageKey::DonationsById),
             donation_ids_by_project_id: LookupMap::new(StorageKey::DonationIdsByProjectId),
             donation_ids_by_donor_id: LookupMap::new(StorageKey::DonationIdsByDonorId),
             patron_donation_ids: UnorderedSet::new(StorageKey::PatronDonationIds),
             payout_ids_by_project_id: LookupMap::new(StorageKey::PayoutsById),
-            payouts_by_id: LookupMap::new(StorageKey::PayoutsById),
+            payouts_by_id: UnorderedMap::new(StorageKey::PayoutsById),
         }
     }
 
@@ -292,12 +292,12 @@ impl Default for Contract {
             approved_project_ids: UnorderedSet::new(StorageKey::ApprovedProjectIds),
             rejected_project_ids: UnorderedSet::new(StorageKey::RejectedProjectIds),
             pending_project_ids: UnorderedSet::new(StorageKey::PendingProjectIds),
-            donations_by_id: LookupMap::new(StorageKey::DonationsById),
+            donations_by_id: UnorderedMap::new(StorageKey::DonationsById),
             donation_ids_by_project_id: LookupMap::new(StorageKey::DonationIdsByProjectId),
             donation_ids_by_donor_id: LookupMap::new(StorageKey::DonationIdsByDonorId),
             patron_donation_ids: UnorderedSet::new(StorageKey::PatronDonationIds),
             payout_ids_by_project_id: LookupMap::new(StorageKey::PayoutsById),
-            payouts_by_id: LookupMap::new(StorageKey::PayoutsById),
+            payouts_by_id: UnorderedMap::new(StorageKey::PayoutsById),
         }
     }
 }

--- a/contracts/pot/src/payouts.rs
+++ b/contracts/pot/src/payouts.rs
@@ -1,0 +1,104 @@
+use crate::*;
+
+// PAYOUTS
+
+pub const PAYOUT_ID_DELIMITER: &str = ":";
+pub type PayoutId = String; // concatenation of project_id + PAYOUT_ID_DELIMITER + incrementing integer per-project
+
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
+#[serde(crate = "near_sdk::serde")]
+pub struct Payout {
+    /// Unique identifier for the payout
+    pub id: PayoutId,
+    /// ID of the project receiving the payout
+    pub project_id: ProjectId,
+    /// Amount paid out
+    pub amount: U128,
+    /// Timestamp when the payout was made. None if not yet paid out.
+    pub paid_at: Option<TimestampMs>,
+}
+
+pub struct PayoutInput {
+    pub amount: U128,
+    pub project_id: ProjectId,
+}
+
+impl Contract {
+    // set_payouts (only callable by chef)
+    pub fn chef_set_payouts(&mut self, payouts: Vec<PayoutInput>) {
+        self.assert_chef();
+        // verify that the round has closed
+        self.assert_round_closed();
+        // verify that payouts have not already been processed
+        assert!(
+            self.paid_out == false,
+            "Payouts have already been processed"
+        );
+        // clear any existing payouts (in case this is a reset, e.g. fixing an error)
+        for approved_project_id in self.approved_project_ids.iter() {
+            if let Some(payout_ids_for_project) =
+                self.payout_ids_by_project_id.get(&approved_project_id)
+            {
+                for payout_id in payout_ids_for_project.iter() {
+                    self.payouts_by_id.remove(&payout_id);
+                }
+                self.payout_ids_by_project_id.remove(&approved_project_id);
+            }
+        }
+        // get down to business
+        let mut running_total: u128 = 0;
+        let balance_available = self
+            .matching_pool_balance
+            .0
+            .checked_add(self.donations_balance.0)
+            .expect(&format!(
+                "Overflow occurred when calculating balance available ({} + {})",
+                self.matching_pool_balance.0, self.donations_balance.0,
+            ));
+        // for each payout:
+        for payout in payouts.iter() {
+            // 1. verify that the project exists and is approved
+            self.assert_approved_project(&payout.project_id);
+            // 2. verify that the project is not already paid out
+            let existing_payout = self.payout_ids_by_project_id.get(&payout.project_id);
+            assert!(
+                existing_payout.is_none(),
+                "Project has already been paid out"
+            );
+            // 3. add amount to running total
+            running_total += payout.amount.0;
+            // error if running total exceeds round total
+            assert!(
+                running_total <= balance_available,
+                "Payouts exceed available balance"
+            );
+            // set cooldown_end to now + 1 week (?)
+            self.cooldown_end_ms = Some(env::block_timestamp_ms() + ONE_WEEK_MS);
+            // add payout to payouts
+            let mut payout_ids_for_project = self
+                .payout_ids_by_project_id
+                .get(&payout.project_id)
+                .unwrap_or(UnorderedSet::new(StorageKey::PayoutIdsByProjectIdInner {
+                    project_id: payout.project_id.clone(),
+                }));
+            let payout_id = format!(
+                "{}{}{}",
+                payout.project_id,
+                PAYOUT_ID_DELIMITER,
+                payout_ids_for_project.len() + 1
+            );
+            let payout = Payout {
+                id: payout_id.clone(),
+                amount: payout.amount,
+                project_id: payout.project_id.clone(),
+                paid_at: None,
+            };
+            payout_ids_for_project.insert(&payout_id);
+            self.payout_ids_by_project_id
+                .insert(&payout.project_id, &payout_ids_for_project);
+            self.payouts_by_id.insert(&payout_id, &payout);
+        }
+    }
+    // get_payouts
+    // challenge_payouts (callable by anyone on ReFi Council)
+}

--- a/contracts/pot/src/payouts.rs
+++ b/contracts/pot/src/payouts.rs
@@ -123,6 +123,7 @@ impl Contract {
                     let mut payout = self.payouts_by_id.get(&payout_id).expect("no payout");
                     if payout.paid_at.is_none() {
                         // ...transfer funds...
+                        // TODO: what happens if this fails?
                         Promise::new(payout.project_id.clone()).transfer(payout.amount.0);
                         // ...and update payout to indicate that funds have been transferred
                         // TODO: handle via Promise callback?
@@ -134,9 +135,10 @@ impl Contract {
         }
     }
 
-    pub fn get_payouts(&self) {
-        // TODO: implement
+    pub fn get_payouts(&self) -> Vec<Payout> {
+        // could add pagination but not necessary initially
+        self.payouts_by_id.values().collect()
     }
-    // get_payouts
+
     // challenge_payouts (callable by anyone on ReFi Council)
 }


### PR DESCRIPTION
Added the following methods:

**`chef_set_payouts`** - for Chef to add payout totals (calculated off-chain). These can be challenged by the ReFi council during the cooldown period (currently set as 1 week) but this logic hasn't been added yet.

**`chef_process_payouts`** - for Chef to make the payouts, has to be after the cooldown period has ended

**`get_payouts`** - get all the `Payout` records on the contract