### PR TITLE
Additional fixes

### DIFF
--- a/contracts/donation/src/donations.rs
+++ b/contracts/donation/src/donations.rs
@@ -46,7 +46,7 @@ impl Contract {
         &mut self,
         recipient_id: AccountId,
         message: Option<String>,
-        referrer_id: Option<AccountId>,
+        mut referrer_id: Option<AccountId>,
     ) -> Donation {
         // user has to pay for storage
         let initial_storage_usage = env::storage_usage();
@@ -61,9 +61,14 @@ impl Contract {
         // calculate referrer fee, if applicable
         let mut referrer_fee = None;
         if let Some(_referrer_id) = referrer_id.clone() {
-            let referrer_amount = self.calculate_referrer_fee(amount);
-            remainder -= referrer_amount;
-            referrer_fee = Some(U128::from(referrer_amount));
+            // if referrer ID is provided, check that it isn't caller or recipient. If it is, set to None
+            if _referrer_id == env::predecessor_account_id() || _referrer_id == recipient_id {
+                referrer_id = None;
+            } else {
+                let referrer_amount = self.calculate_referrer_fee(amount);
+                remainder -= referrer_amount;
+                referrer_fee = Some(U128::from(referrer_amount));
+            }
         }
 
         // get donation count, which will be incremented to create the unique donation ID

--- a/contracts/donation/src/donations.rs
+++ b/contracts/donation/src/donations.rs
@@ -135,14 +135,14 @@ impl Contract {
 
     pub(crate) fn calculate_protocol_fee(&self, amount: u128) -> u128 {
         let total_basis_points = 10_000u128;
-        let fee_amount = self.protocol_fee_basis_points as u128 * amount;
+        let fee_amount = (self.protocol_fee_basis_points as u128).saturating_mul(amount);
         // Round up
         fee_amount.div_ceil(total_basis_points)
     }
 
     pub(crate) fn calculate_referrer_fee(&self, amount: u128) -> u128 {
         let total_basis_points = 10_000u128;
-        let fee_amount = self.referral_fee_basis_points as u128 * amount;
+        let fee_amount = (self.referral_fee_basis_points as u128).saturating_mul(amount);
         // Round down
         fee_amount / total_basis_points
     }

--- a/contracts/donation/src/owner.rs
+++ b/contracts/donation/src/owner.rs
@@ -7,7 +7,9 @@ impl Contract {
     pub fn owner_change_owner(&mut self, owner: AccountId) {
         // TODO: consider renaming to owner_set_owner, but currently deployed Registry uses owner_change_owner.
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         self.owner = owner;
+        refund_deposit(initial_storage_usage);
     }
 
     pub fn get_owner(&self) -> AccountId {
@@ -18,14 +20,18 @@ impl Contract {
     #[payable]
     pub fn owner_set_protocol_fee_basis_points(&mut self, protocol_fee_basis_points: u32) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         self.protocol_fee_basis_points = protocol_fee_basis_points;
+        refund_deposit(initial_storage_usage);
     }
 
     // referral_fee_basis_points
     #[payable]
     pub fn owner_set_referral_fee_basis_points(&mut self, referral_fee_basis_points: u32) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         self.referral_fee_basis_points = referral_fee_basis_points;
+        refund_deposit(initial_storage_usage);
     }
 
     // protocol_fee_recipient_account
@@ -35,6 +41,8 @@ impl Contract {
         protocol_fee_recipient_account: AccountId,
     ) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         self.protocol_fee_recipient_account = protocol_fee_recipient_account;
+        refund_deposit(initial_storage_usage);
     }
 }

--- a/contracts/pot/src/admin.rs
+++ b/contracts/pot/src/admin.rs
@@ -60,8 +60,9 @@ impl Contract {
     pub fn owner_set_admins(&mut self, account_ids: Vec<AccountId>) {
         self.assert_owner();
         let initial_storage_usage = env::storage_usage();
+        self.admins.clear();
         for account_id in account_ids {
-            self.admins.remove(&account_id);
+            self.admins.insert(&account_id);
         }
         refund_deposit(initial_storage_usage);
     }

--- a/contracts/pot/src/applications.rs
+++ b/contracts/pot/src/applications.rs
@@ -261,8 +261,6 @@ impl Contract {
                 .get(&project_id)
                 .expect("Application does not exist"),
         );
-        // check that max_projects hasn't been reached
-        self.assert_max_projects_not_reached();
         // update application
         let previous_status = application.status.clone();
         application.status = status;
@@ -275,6 +273,8 @@ impl Contract {
         );
         // insert into approved applications mapping if approved
         if application.status == ApplicationStatus::Approved {
+            // check that max_projects hasn't been reached
+            self.assert_max_projects_not_reached();
             self.approved_application_ids.insert(&project_id);
         } else {
             // setting application status as something other than Approved; if it was previously approved, remove from approved mapping

--- a/contracts/pot/src/donations.rs
+++ b/contracts/pot/src/donations.rs
@@ -200,7 +200,7 @@ impl Contract {
 
     pub(crate) fn calculate_fee(&self, amount: u128, basis_points: u32, is_protocol: bool) -> u128 {
         let total_basis_points = 10_000u128;
-        let fee_amount = basis_points as u128 * amount;
+        let fee_amount = (basis_points as u128).saturating_mul(amount);
         if !is_protocol {
             // round down
             fee_amount / total_basis_points

--- a/contracts/pot_factory/src/admin.rs
+++ b/contracts/pot_factory/src/admin.rs
@@ -11,6 +11,7 @@ impl Contract {
     #[payable]
     pub fn owner_set_admins(&mut self, account_ids: Vec<AccountId>) {
         self.assert_owner();
+        self.admins.clear();
         for account_id in account_ids {
             self.admins.insert(&account_id);
         }

--- a/contracts/pot_factory/src/admin.rs
+++ b/contracts/pot_factory/src/admin.rs
@@ -5,44 +5,56 @@ impl Contract {
     #[payable]
     pub fn owner_change_owner(&mut self, new_owner: AccountId) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         self.owner = new_owner;
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
     pub fn owner_set_admins(&mut self, account_ids: Vec<AccountId>) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         self.admins.clear();
         for account_id in account_ids {
             self.admins.insert(&account_id);
         }
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
     pub fn owner_add_admins(&mut self, account_ids: Vec<AccountId>) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         for account_id in account_ids {
             self.admins.insert(&account_id);
         }
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
     pub fn owner_remove_admins(&mut self, account_ids: Vec<AccountId>) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         for account_id in account_ids {
             self.admins.remove(&account_id);
         }
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
     pub fn owner_clear_admins(&mut self) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         self.admins.clear();
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
     pub fn admin_set_protocol_fee_basis_points(&mut self, protocol_fee_basis_points: u32) {
         self.assert_admin_or_greater();
+        let initial_storage_usage = env::storage_usage();
         self.protocol_fee_basis_points = protocol_fee_basis_points;
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
@@ -51,7 +63,9 @@ impl Contract {
         protocol_fee_recipient_account: AccountId,
     ) {
         self.assert_admin_or_greater();
+        let initial_storage_usage = env::storage_usage();
         self.protocol_fee_recipient_account = protocol_fee_recipient_account;
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
@@ -61,35 +75,45 @@ impl Contract {
         protocol_fee_recipient_account: AccountId,
     ) {
         self.assert_admin_or_greater();
+        let initial_storage_usage = env::storage_usage();
         self.protocol_fee_basis_points = protocol_fee_basis_points;
         self.protocol_fee_recipient_account = protocol_fee_recipient_account;
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
     pub fn admin_set_default_chef_fee_basis_points(&mut self, default_chef_fee_basis_points: u32) {
         self.assert_admin_or_greater();
+        let initial_storage_usage = env::storage_usage();
         self.default_chef_fee_basis_points = default_chef_fee_basis_points;
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
     pub fn admin_add_whitelisted_deployers(&mut self, whitelisted_deployers: Vec<AccountId>) {
         self.assert_admin_or_greater();
+        let initial_storage_usage = env::storage_usage();
         for account_id in whitelisted_deployers {
             self.whitelisted_deployers.insert(&account_id);
         }
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
     pub fn admin_remove_whitelisted_deployers(&mut self, whitelisted_deployers: Vec<AccountId>) {
         self.assert_admin_or_greater();
+        let initial_storage_usage = env::storage_usage();
         for account_id in whitelisted_deployers {
             self.whitelisted_deployers.remove(&account_id);
         }
+        refund_deposit(initial_storage_usage);
     }
 
     #[payable]
     pub fn admin_set_require_whitelist(&mut self, require_whitelist: bool) {
         self.assert_admin_or_greater();
+        let initial_storage_usage = env::storage_usage();
         self.require_whitelist = require_whitelist;
+        refund_deposit(initial_storage_usage);
     }
 }

--- a/contracts/pot_factory/src/utils.rs
+++ b/contracts/pot_factory/src/utils.rs
@@ -16,3 +16,30 @@ pub fn calculate_required_storage_deposit(initial_storage_usage: u64) -> Balance
     let required_cost = env::storage_byte_cost() * Balance::from(storage_used);
     required_cost
 }
+
+pub fn refund_deposit(initial_storage_usage: u64) {
+    let attached_deposit = env::attached_deposit();
+    let mut refund = attached_deposit;
+    if env::storage_usage() > initial_storage_usage {
+        // caller should pay for the extra storage they used and be refunded for the rest
+        // let storage_used = env::storage_usage() - initial_storage_usage;
+        let required_deposit = calculate_required_storage_deposit(initial_storage_usage);
+        // env::storage_byte_cost() * Balance::from(storage_used);
+        require!(
+            required_deposit <= attached_deposit,
+            format!(
+                "Must attach {} yoctoNEAR to cover storage",
+                required_deposit
+            )
+        );
+        refund -= required_deposit;
+    } else {
+        // storage was freed up; caller should be refunded for what they freed up, in addition to the deposit they sent
+        let storage_freed = initial_storage_usage - env::storage_usage();
+        let cost_freed = env::storage_byte_cost() * Balance::from(storage_freed);
+        refund += cost_freed;
+    }
+    if refund > 1 {
+        Promise::new(env::predecessor_account_id()).transfer(refund);
+    }
+}

--- a/contracts/registry/src/admins.rs
+++ b/contracts/registry/src/admins.rs
@@ -5,9 +5,11 @@ impl Contract {
     #[payable]
     pub fn owner_add_admins(&mut self, admins: Vec<AccountId>) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         for admin in admins {
             self.admins.insert(&admin);
         }
+        refund_deposit(initial_storage_usage);
     }
 
     pub fn get_admins(&self) -> Vec<AccountId> {
@@ -17,8 +19,10 @@ impl Contract {
     #[payable]
     pub fn owner_remove_admins(&mut self, admins: Vec<AccountId>) {
         self.assert_owner();
+        let initial_storage_usage = env::storage_usage();
         for admin in admins {
             self.admins.remove(&admin);
         }
+        refund_deposit(initial_storage_usage);
     }
 }

--- a/contracts/sybil/src/admin.rs
+++ b/contracts/sybil/src/admin.rs
@@ -12,11 +12,13 @@ impl Contract {
         // check that provider exists
         if let Some(versioned_provider) = self.providers_by_id.get(&provider_id) {
             // update provider
+            let initial_storage_usage = env::storage_usage();
             let mut provider = Provider::from(versioned_provider);
             provider.is_active = true;
             provider.default_weight = default_weight;
             self.providers_by_id
                 .insert(&provider_id, &VersionedProvider::Current(provider.clone()));
+            refund_deposit(initial_storage_usage);
             provider
         } else {
             env::panic_str("Provider does not exist");
@@ -29,12 +31,14 @@ impl Contract {
         // check that provider exists
         if let Some(versioned_provider) = self.providers_by_id.get(&provider_id) {
             // update provider
+            let initial_storage_usage = env::storage_usage();
             let mut provider = Provider::from(versioned_provider);
             provider.is_active = false;
             self.providers_by_id
                 .insert(&provider_id, &VersionedProvider::Current(provider.clone()));
             // remove provider from devault providers
             self.default_provider_ids.remove(&provider_id);
+            refund_deposit(initial_storage_usage);
             // return provider
             provider
         } else {
@@ -48,10 +52,12 @@ impl Contract {
         // check that provider exists
         if let Some(versioned_provider) = self.providers_by_id.get(&provider_id) {
             // update provider
+            let initial_storage_usage = env::storage_usage();
             let mut provider = Provider::from(versioned_provider);
             provider.is_flagged = true;
             self.providers_by_id
                 .insert(&provider_id, &VersionedProvider::Current(provider.clone()));
+            refund_deposit(initial_storage_usage);
             provider
         } else {
             env::panic_str("Provider does not exist");
@@ -64,10 +70,12 @@ impl Contract {
         // check that provider exists
         if let Some(versioned_provider) = self.providers_by_id.get(&provider_id) {
             // update provider
+            let initial_storage_usage = env::storage_usage();
             let mut provider = Provider::from(versioned_provider);
             provider.is_flagged = false;
             self.providers_by_id
                 .insert(&provider_id, &VersionedProvider::Current(provider.clone()));
+            refund_deposit(initial_storage_usage);
             provider
         } else {
             env::panic_str("Provider does not exist");
@@ -84,10 +92,12 @@ impl Contract {
         // check that provider exists
         if let Some(versioned_provider) = self.providers_by_id.get(&provider_id) {
             // update its ID by replacing the old key with the new key
+            let initial_storage_usage = env::storage_usage();
             let (contract_id, old_method_name) = provider_id.decompose();
             let new_id = ProviderId::new(contract_id, method_name.clone());
             self.providers_by_id.remove(&provider_id);
             self.providers_by_id.insert(&new_id, &versioned_provider);
+            refund_deposit(initial_storage_usage);
             Provider::from(self.providers_by_id.get(&new_id).unwrap())
         } else {
             env::panic_str("Provider does not exist");


### PR DESCRIPTION
- (Donation) If `referrer_id` is caller or recipient, ignore it
- Use `saturating_mul` when calculating fees to prevent (extremely unlikely) u128 overflow during multiplication
- Move location of `assert_max_projects_not_reached` to only run when approving application
- Fix logic in `owner_set_admins` (ensure existing set is cleared; ensure insertion of new admins rather than removal)
- Refund unused deposit in all admin methods that require deposit for security purposes