### PR TITLE
Feat/optional fees

### DIFF
--- a/contracts/donation/README.md
+++ b/contracts/donation/README.md
@@ -107,6 +107,7 @@ pub fn donate(
     recipient_id: AccountId,
     message: Option<String>,
     referrer_id: Option<AccountId>,
+    bypass_protocol_fee: Option<bool>, // Allows donor to bypass protocol fee if they wish. Defaults to "false".
 ) -> Donation
 
 

--- a/contracts/donation/src/donations.rs
+++ b/contracts/donation/src/donations.rs
@@ -54,12 +54,11 @@ impl Contract {
 
         // calculate protocol fee (unless bypassed)
         let amount = env::attached_deposit();
-        let mut protocol_fee = self.calculate_protocol_fee(amount);
-        if let Some(bypass_protocol_fee) = bypass_protocol_fee {
-            if bypass_protocol_fee {
-                protocol_fee = 0;
-            }
-        }
+        let protocol_fee = if bypass_protocol_fee.unwrap_or(false) {
+            0
+        } else {
+            self.calculate_protocol_fee(amount)
+        };
         let mut remainder: u128 = amount;
         remainder -= protocol_fee;
 

--- a/contracts/pot/README.md
+++ b/contracts/pot/README.md
@@ -441,6 +441,7 @@ pub fn donate(
     message: Option<String>,
     referrer_id: Option<AccountId>,
     matching_pool: Option<bool>,
+    bypass_protocol_fee: Option<bool>, // Allows donor to bypass protocol fee if they wish. Defaults to "false".
 ) -> DonationExternal
 
 


### PR DESCRIPTION
Add `bypass_protocol_fee: Option<bool>` to `donate` methods on both Donation and Pot contracts, allowing donor to bypass the protocol fee if they explicitly choose to do so.